### PR TITLE
HOME-235 - Separate services from one Docker in to multiple

### DIFF
--- a/smarthome-deployment.yaml
+++ b/smarthome-deployment.yaml
@@ -28,9 +28,21 @@ spec:
         app: smarthome-server
     spec:
       containers:
-        - image: oszura/smarthome-server-prod
+        - image: oszura/sh-dashboard-prod
           imagePullPolicy: Always
-          name: smarthome-server-prod
+          name: sh-dashboard-prod
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        - image: oszura/sh-influxdb
+          imagePullPolicy: Always
+          name: sh-influxdb
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        - image: oszura/sh-mongodb
+          imagePullPolicy: Always
+          name: sh-mongodb
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
@@ -40,11 +52,10 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
-        securityContext: {}
-        terminationGracePeriodSeconds: 30
-        volumes:
-          - name: mongo-db
-            hostPath:
-              path: /data/db-backup
-              type: Directory
-      status: {}
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: mongo-db
+          hostPath:
+            path: /data/db-backup
+            type: Directory


### PR DESCRIPTION
**Business justification:** https://trello.com/c/N3b5qUTW/235-home-235-separate-services-from-one-docker-in-to-multiple

**Description:** Previously we had one pod with only one Docker container, which had influxdb, mongodb and smarthome-dashboard started. This PR is a Kubernetes adjustment for splitting one major Docker image into multiple with one service per conainer.

Related PRs:
* https://github.com/smart-evolution/smarthome-server/pull/21